### PR TITLE
Session expirations, character creation restrictions and test session… (merge from upstream)

### DIFF
--- a/libcomp/schema/character.xml
+++ b/libcomp/schema/character.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <objgen>
     <object name="Character" location="world">
-        <member type="string" name="Name" size="32"/>
+        <member type="string" name="Name" size="32" key="true" unique="true"/>
         <member type="Account*" name="Account" key="true" unique="false"/>
         <member type="u8" name="CID" caps="true" max="19"/>
         <member type="u8" name="WorldID"/>

--- a/libcomp/src/PacketCodes.h
+++ b/libcomp/src/PacketCodes.h
@@ -77,6 +77,7 @@ enum class ClientToChannelPacketCode_t : uint16_t
     PACKET_CHAT = 0x0026, //!< Request to add a message to the chat or process a GM command.
     PACKET_ACTIVATE_SKILL = 0x0030, //!< Request to activate a player or demon skill.
     PACKET_EXECUTE_SKILL = 0x0031, //!< Request to execute a skill that has finished charging.
+    PACKET_CANCEL_SKILL = 0x0032, //!< Request to execute a skill that has finished charging.
     PACKET_ALLOCATE_SKILL_POINT = 0x0049, //!< Request to allocate a skill point for a character.
     PACKET_TOGGLE_EXPERTISE = 0x004F, //!< Request to enable or disable an expertise.
     PACKET_LEARN_SKILL = 0x0051, //!< Request for a character to learn a skill.

--- a/server/channel/CMakeLists.txt
+++ b/server/channel/CMakeLists.txt
@@ -105,6 +105,7 @@ SET(${PROJECT_NAME}_PACKETS
     src/packets/game/Chat.cpp               # 0x0026
     src/packets/game/ActivateSkill.cpp      # 0x0030
     src/packets/game/ExecuteSkill.cpp       # 0x0031
+    src/packets/game/CancelSkill.cpp        # 0x0032
     src/packets/game/AllocateSkillPoint.cpp # 0x0049
     src/packets/game/ToggleExpertise.cpp    # 0x004F
     src/packets/game/LearnSkill.cpp         # 0x0051

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -120,6 +120,8 @@ bool ChannelServer::Initialize()
         to_underlying(ClientToChannelPacketCode_t::PACKET_ACTIVATE_SKILL));
     clientPacketManager->AddParser<Parsers::ExecuteSkill>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_EXECUTE_SKILL));
+    clientPacketManager->AddParser<Parsers::CancelSkill>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_CANCEL_SKILL));
     clientPacketManager->AddParser<Parsers::AllocateSkillPoint>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_ALLOCATE_SKILL_POINT));
     clientPacketManager->AddParser<Parsers::ToggleExpertise>(

--- a/server/channel/src/CharacterManager.cpp
+++ b/server/channel/src/CharacterManager.cpp
@@ -1093,9 +1093,18 @@ bool CharacterManager::AddRemoveItem(const std::shared_ptr<
             }
         }
 
+        auto equipType = def->GetBasic()->GetEquipType();
+
         uint16_t removed = 0;
         for(auto item : existing)
         {
+            // Unequip anything we're removing
+            if(equipType != objects::MiItemBasicData::EquipType_t::EQUIP_TYPE_NONE &&
+                character->GetEquippedItems((size_t)equipType).Get() == item)
+            {
+                EquipItem(client, state->GetObjectID(item->GetUUID()));
+            }
+
             auto slot = item->GetBoxSlot();
             if(item->GetStackSize() <= (quantity - removed))
             {
@@ -1225,7 +1234,7 @@ void CharacterManager::EquipItem(const std::shared_ptr<
     reply.WriteS16Little(cs->GetPDEF());
     reply.WriteS16Little(cs->GetMDEF());
 
-    client->SendPacket(reply);
+    server->GetZoneManager()->BroadcastPacket(client, reply);
 }
 
 void CharacterManager::UpdateLNC(const std::shared_ptr<
@@ -1523,8 +1532,7 @@ void CharacterManager::UpdateExpertise(const std::shared_ptr<
             reply.WriteS8((int8_t)expDef->GetID());
             reply.WriteS8(newRank);
 
-            /// @todo: Does this need to send to the rest of the zone?
-            client->SendPacket(reply);
+            server->GetZoneManager()->BroadcastPacket(client, reply);
         }
     }
 

--- a/server/channel/src/Packets.h
+++ b/server/channel/src/Packets.h
@@ -45,6 +45,7 @@ PACKET_PARSER_DECL(Move);                // 0x001C
 PACKET_PARSER_DECL(Chat);                // 0x0026
 PACKET_PARSER_DECL(ActivateSkill);       // 0x0030
 PACKET_PARSER_DECL(ExecuteSkill);        // 0x0031
+PACKET_PARSER_DECL(CancelSkill);         // 0x0032
 PACKET_PARSER_DECL(AllocateSkillPoint);  // 0x0049
 PACKET_PARSER_DECL(ToggleExpertise);     // 0x004F
 PACKET_PARSER_DECL(LearnSkill);          // 0x0051

--- a/server/channel/src/SkillManager.h
+++ b/server/channel/src/SkillManager.h
@@ -85,6 +85,16 @@ public:
         int32_t sourceEntityID, uint8_t activationID, int64_t targetObjectID);
 
     /**
+     * Cancel the activated skill of a character or demon.
+     * @param client Pointer to the client connection that activated the skill
+     * @param sourceEntityID ID of the entity that activated the skill
+     * @param activationID ID of the activated ability instance
+     * @return true if the skill was cancelled successfully, false otherwise
+     */
+    bool CancelSkill(const std::shared_ptr<ChannelClientConnection> client,
+        int32_t sourceEntityID, uint8_t activationID);
+
+    /**
      * Notify the client that a skill failed activation or execution.
      * @param client Pointer to the client connection that activated the skill
      * @param sourceEntityID ID of the entity that activated the skill
@@ -186,9 +196,11 @@ private:
      * @param client Pointer to the client connection that activated the skill
      * @param sourceEntityID ID of the entity that activated the skill
      * @param activated Pointer to the activated ability instance
+     * @param cancelled true if the skill was cancelled
      */
     void SendCompleteSkill(const std::shared_ptr<ChannelClientConnection> client,
-        int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated);
+        int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated,
+        bool cancelled);
 
     /// Pointer to the channel server
     std::weak_ptr<ChannelServer> mServer;

--- a/server/channel/src/packets/game/CancelSkill.cpp
+++ b/server/channel/src/packets/game/CancelSkill.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file server/channel/src/packets/game/CancelSkill.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Request from the client to cancel a skill that was activated.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <ManagerPacket.h>
+
+// channel Includes
+#include "ChannelServer.h"
+
+using namespace channel;
+
+void SkillCancellation(SkillManager* skillManager,
+    const std::shared_ptr<ChannelClientConnection> client,
+    int32_t sourceEntityID, uint8_t activationID)
+{
+    skillManager->CancelSkill(client, sourceEntityID, activationID);
+}
+
+bool Parsers::CancelSkill::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    if(p.Size() < 5)
+    {
+        return false;
+    }
+
+    auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
+    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
+    auto skillManager = server->GetSkillManager();
+
+    int32_t sourceEntityID = p.ReadS32Little();
+    uint8_t activationID = p.ReadU8();
+
+    server->QueueWork(SkillCancellation, skillManager, client, sourceEntityID, activationID);
+
+    return true;
+}

--- a/server/channel/src/packets/game/ItemDrop.cpp
+++ b/server/channel/src/packets/game/ItemDrop.cpp
@@ -38,6 +38,8 @@
 #include <Character.h>
 #include <Item.h>
 #include <ItemBox.h>
+#include <MiItemBasicData.h>
+#include <MiItemData.h>
 
 // channel Includes
 #include "ChannelServer.h"
@@ -63,6 +65,17 @@ void DropItem(const std::shared_ptr<ChannelServer> server,
     auto itemBox = item->GetItemBox().Get();
     if(nullptr != itemBox)
     {
+        // Unequip if needed
+        auto def = server->GetDefinitionManager()->GetItemData(item->GetType());
+        auto equipType = def != nullptr ? def->GetBasic()->GetEquipType()
+            : objects::MiItemBasicData::EquipType_t::EQUIP_TYPE_NONE;
+        if(equipType != objects::MiItemBasicData::EquipType_t::EQUIP_TYPE_NONE &&
+            character->GetEquippedItems((size_t)equipType).Get() == item)
+        {
+            server->GetCharacterManager()
+                ->EquipItem(client, state->GetObjectID(item->GetUUID()));
+        }
+
         itemBox->SetItems((size_t)item->GetBoxSlot(), NULLUUID);
 
         auto worldDB = server->GetWorldDatabase();

--- a/server/lobby/src/SessionManager.h
+++ b/server/lobby/src/SessionManager.h
@@ -56,16 +56,28 @@ public:
      * @param username Username of the account.
      * @param value Value to check against the SID.
      * @param newSID Value of the new SID.
-     * @return If the value matches what was recorded.
+     * @return If the value matches what was recorded and
+     *  there is either no timeout or it has not passed.
      */
     bool CheckSID(const libcomp::String& username,
         const libcomp::String& value, libcomp::String& newSID);
 
     /**
-     * Clear an account's session.
+     * Clear an account's session or set an expiration timeout.
+     * @param username Username of the account.
+     * @param timeout Optional parameter to invalidate the
+     *  session after the specified time offset has passed.
+     *  If a negative value is specified (or defaulted) the
+     *  timeout will not be used.
+     */
+    void ExpireSession(const libcomp::String& username,
+        int8_t timeout = -1);
+
+    /**
+     * Clear an account session's expiration timeout.
      * @param username Username of the account.
      */
-    void ExpireSession(const libcomp::String& username);
+    void RefreshSession(const libcomp::String& username);
 
 private:
     /// Lock for access to the session map.
@@ -74,6 +86,9 @@ private:
     /// Map of accounts with associated session IDs.
     std::unordered_map<libcomp::String,
         std::pair<libcomp::String, libcomp::String>> mSessionMap;
+
+    /// Map of accounts with timeouts for session validation.
+    std::unordered_map<libcomp::String, time_t> mTimeoutMap;
 };
 
 } // namespace lobby

--- a/server/lobby/src/packets/game/StartGame.cpp
+++ b/server/lobby/src/packets/game/StartGame.cpp
@@ -79,6 +79,10 @@ bool Parsers::StartGame::Parse(libcomp::ManagerPacket *pPacketManager,
         return false;
     }
 
+    // Expire session with current time, meaning until we hear back from the
+    // channel that the login took place, do not consider the connection valid
+    server->GetSessionManager()->ExpireSession(username, 0);
+
     auto login = accountManager->GetUserLogin(username);
     login->SetCID(cid);
 

--- a/server/lobby/src/packets/internal/AccountLogin.cpp
+++ b/server/lobby/src/packets/internal/AccountLogin.cpp
@@ -114,7 +114,10 @@ void UpdateAccountLogin(std::shared_ptr<LobbyServer> server,
     {
         return;
     }
-    accountManager->LoginUser(account->GetUsername(), login);
+    accountManager->LoginUser(username, login);
+
+    //Clear the session expiration
+    server->GetSessionManager()->RefreshSession(username);
 }
 
 bool Parsers::AccountLogin::Parse(libcomp::ManagerPacket *pPacketManager,

--- a/server/lobby/src/packets/internal/AccountLogout.cpp
+++ b/server/lobby/src/packets/internal/AccountLogout.cpp
@@ -60,7 +60,8 @@ bool Parsers::AccountLogout::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         LOG_DEBUG(libcomp::String("Logging out user: '%1'\n").Arg(username));
         accountManager->LogoutUser(username, worldID);
-        server->GetSessionManager()->ExpireSession(username);
+        // Invalidate the session in 60 seconds
+        server->GetSessionManager()->ExpireSession(username, 60);
     }
 
     return true;


### PR DESCRIPTION
… fixes (#145)

* Unique character names and more accurate character creation error codes

* More lenient session handling between the channel and lobby servers via timeout

* Skill cancelling, unequipping items being discarded and more multi-client visible packets in response to testing issues