### PR TITLE
Minor cleanup of the encoding of outgoing chat messages (#144)

### DIFF
--- a/libcomp/src/Constants.h
+++ b/libcomp/src/Constants.h
@@ -30,6 +30,9 @@
 namespace libcomp
 {
 
+/// Maximum length of a chat message.
+#define MAX_MESSAGE_LENGTH (80)
+
 /// Number of bits in a Blowfish key.
 #define BF_NET_KEY_BIT_SIZE (64)
 


### PR DESCRIPTION
[MOD] Reduced the number of conversions/wrappers of the encoded string.
[ADD] Check on the length of the encoded string to prevent the WriteBlank from performing bad math.
[MOD] Reused the same client state so it isn't pulled multiple times.
[ADD] Constant for the maximum message length.